### PR TITLE
Adding --show-cred option for Issue #1

### DIFF
--- a/linux/bash/login/README.md
+++ b/linux/bash/login/README.md
@@ -9,7 +9,7 @@ imlogin my-server
 ```
 
 ```
-Logging to 03.01.200.900 with credentials satoshi:satoshispassword ...
+Logging to 03.01.200.900 with user: satoshi ...
 
 Last login: Sat Jan 03 11:45:00 2009 from 04.01.202.200
 [satoshi@my-server ~]$ 
@@ -98,6 +98,18 @@ imlogin admin@paras-server
 You can also skip the username if you want to login with the `default_user` (if given):
 ```
 imlogin paras-server
+```
+
+```
+Logging to 03.01.200.900 with user: paras ...
+
+Last login: Sat Jan 03 11:45:00 2009 from 04.01.202.200
+[paras@server-hostname-can-be-different-from-server-alias ~]$ 
+```
+
+If you want the password to be visible in the output of command then you can pass `--show-cred` argument in the command:
+```sh
+imlogin paras-server --show-cred
 ```
 
 ```

--- a/linux/bash/login/imlogin.sh
+++ b/linux/bash/login/imlogin.sh
@@ -28,6 +28,11 @@ function imlogin() {
         return;
     fi
 
+    SHOW_CRED=
+    if [ "$2" = "--show-cred" ]; then
+        SHOW_CRED=1
+    fi
+
     IFS='@';
     read -ra CRED <<< "$1";
     IFS=' ';
@@ -48,9 +53,13 @@ function imlogin() {
     IP=`jq -r --arg server "$SERVER_NAME" '.[$server].ip' $CONFIG_FILE`;
     PASSWORD=`jq -r --arg server "$SERVER_NAME" --arg username "$USER_NAME" '.[$server].cred[$username]' $CONFIG_FILE`;
 
-    echo -e "\nLogging to $IP with credentials $USER_NAME:$PASSWORD ...\n";
+    if [ $SHOW_CRED ]; then
+        echo -e "\nLogging to $IP with credentials $USER_NAME:$PASSWORD ...\n"
 
-    echo -e "sshpass -p $PASSWORD ssh $USER_NAME@$IP\n\n";
+        echo -e "sshpass -p $PASSWORD ssh $USER_NAME@$IP\n\n"
+    else
+        echo -e "\nLogging to $IP with user: $USER_NAME ...\n"
+    fi
 
     sshpass -p $PASSWORD ssh $USER_NAME@$IP;
 


### PR DESCRIPTION
This PR is to solve the issue #1 

Now the default output of `imlogin` command will not contain password for security purpose, If you want to show it then you can pass the new flag `--show-cred` as second argument.

**eg. 1: Without Password (Default)**

```sh
imlogin paras-server
```

```
Logging to 03.01.200.900 with user: paras ...

Last login: Sat Jan 03 11:45:00 2009 from 04.01.202.200
[paras@server-hostname-can-be-different-from-server-alias ~]$ 
```

**eg.2: With Password (New option `--show-cred`)**

```sh
imlogin paras-server --show-cred
```

```
Logging to 03.01.200.900 with credentials paras:youcantseeme ...

Last login: Sat Jan 03 11:45:00 2009 from 04.01.202.200
[paras@server-hostname-can-be-different-from-server-alias ~]$ 
```